### PR TITLE
Added retries to downloadFile method on seed-utils to avoid timeouts.

### DIFF
--- a/prisma/seed-utils.ts
+++ b/prisma/seed-utils.ts
@@ -3,13 +3,22 @@ import { faker } from '@faker-js/faker'
 import bcrypt from 'bcryptjs'
 import { type PrismaClient } from '@prisma/client'
 
-export async function downloadFile(url: string) {
-	const response = await fetch(url)
-	if (!response.ok) {
-		throw new Error(`Failed to fetch image with status ${response.status}`)
-	}
-	const blob = Buffer.from(await response.arrayBuffer())
-	return blob
+export async function downloadFile(
+  url: string,
+  retries: number = 0,
+): Promise<Buffer> {
+  const MAX_RETRIES = 3
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch image with status ${response.status}`)
+    }
+    const blob = Buffer.from(await response.arrayBuffer())
+    return blob
+  } catch (e) {
+    if (retries > MAX_RETRIES) throw e
+    return downloadFile(url, retries + 1)
+  }
 }
 
 export function createContactInfo(): Omit<


### PR DESCRIPTION
When I tried to run `npm run setup` I was always getting timeout when downloading the images, so I added a recursive retry and it solved the issue for me.