### PR TITLE
fix user bio

### DIFF
--- a/app/routes/settings+/profile.tsx
+++ b/app/routes/settings+/profile.tsx
@@ -366,6 +366,7 @@ export default function EditUserProfile() {
 									children: 'Host Bio',
 								}}
 								textareaProps={{
+									...fields.hostBio.props,
 									defaultValue: data.user.host?.bio ?? '',
 									disabled: !data.user.host,
 									ref: hostBioTextareaRef,

--- a/app/routes/users_+/__shared.tsx
+++ b/app/routes/users_+/__shared.tsx
@@ -213,11 +213,15 @@ export function UserProfileBasicInfo({
 							</div>
 						</div>
 					</div>
-					<div className="rounded-3xl bg-night-muted p-10">
+					<div className="flex flex-col rounded-3xl bg-night-muted p-10">
 						<h2 className="font-3xl font-bold text-white">About</h2>
-						<p className="mt-6 max-h-56 overflow-y-scroll text-label-light-gray">
-							{bio ?? 'No bio provided'}
-						</p>
+						<div className="mt-6 max-h-56 flex-grow overflow-y-auto text-label-light-gray">
+							{bio
+								? bio
+										.split('\n')
+										.map((line, index) => <p key={index}>{line}</p>)
+								: 'No bio provided'}
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Hey @kentcdodds,

This PR fixed these issues:
1. missing hostBio (typescript did not show any error on missing props)
2. render multi-line bio in the user about section.
3. fix visible scrollbar (i see it on windows 11, did not test it on other platforms)