### PR TITLE
fix: vitest afterAll fails on Windows

### DIFF
--- a/other/test-setup/setup-test-env.ts
+++ b/other/test-setup/setup-test-env.ts
@@ -3,7 +3,7 @@ import { installGlobals } from '@remix-run/node'
 import { matchers, type TestingLibraryMatchers } from './matchers.cjs'
 import 'dotenv/config'
 import fs from 'fs'
-import { db } from '~/utils/db.server.ts'
+import { db, prisma } from '~/utils/db.server.ts'
 import { BASE_DATABASE_PATH, DATABASE_PATH } from './paths.ts'
 import { deleteAllData } from './utils.ts'
 import '../../mocks/index.ts'
@@ -26,5 +26,7 @@ afterEach(() => {
 })
 
 afterAll(async () => {
+	db.close()
+	await prisma.$disconnect()
 	await fs.promises.rm(DATABASE_PATH)
 })


### PR DESCRIPTION
this fix this issue here

but is see many warnings from MSW]
```
stderr | app/routes/bookings+/$bookingId.test.tsx > returns 404 for a booking that does not involve the user
[MSW] Warning: captured a request without a matching request handler:

  • GET https://loremflickr.com/512/512/transport

If you still wish to intercept this unhandled request, please create a request handler for it.
Read more: https://mswjs.io/docs/getting-started/mocks

stderr | app/routes/ships_+/$shipId.book.test.tsx > returns booking data from the session
[MSW] Warning: captured a request without a matching request handler:

  • GET https://loremflickr.com/512/512/nature

If you still wish to intercept this unhandled request, please create a request handler for it.
Read more: https://mswjs.io/docs/getting-started/mocks
```