### PR TITLE
This is not a PR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ FROM base as deps
 WORKDIR /myapp
 
 ADD package.json package-lock.json .npmrc ./
-RUN npm install --production=false
-
+RUN npm ci --omit=dev
 # Setup production node_modules
 FROM base as production-deps
 
@@ -22,7 +21,6 @@ WORKDIR /myapp
 
 COPY --from=deps /myapp/node_modules /myapp/node_modules
 ADD package.json package-lock.json .npmrc ./
-RUN npm prune --production
 
 # Build the app
 FROM base as build


### PR DESCRIPTION
This is more like an issue with code.

It should be possible to install the application in production.
So everything should be in `"dependencies":` to go from source code to full production installation.

Currently the installation process mixes devdeps with deps.
